### PR TITLE
Added optional prop to adjust aspect ratio

### DIFF
--- a/lib/ComposableMap.js
+++ b/lib/ComposableMap.js
@@ -58,7 +58,8 @@ var ComposableMap = function (_Component) {
           height = _props2.height,
           style = _props2.style,
           showCenter = _props2.showCenter,
-          children = _props2.children;
+          children = _props2.children,
+          aspectRatio = _props2.aspectRatio;
 
 
       return _react2.default.createElement(
@@ -67,7 +68,8 @@ var ComposableMap = function (_Component) {
           height: height,
           viewBox: "0 0 " + width + " " + height,
           className: "rsm-svg",
-          style: style },
+          style: style,
+          preserveAspectRatio: aspectRatio },
         _react2.default.cloneElement(this.props.children, {
           projection: this.projection,
           width: width,
@@ -90,7 +92,8 @@ ComposableMap.defaultProps = {
   width: 800,
   height: 450,
   projection: "times",
-  projectionConfig: _projectionConfig2.default
+  projectionConfig: _projectionConfig2.default,
+  aspectRatio: "xMidYMid"
 };
 
 exports.default = ComposableMap;

--- a/src/ComposableMap.js
+++ b/src/ComposableMap.js
@@ -14,7 +14,7 @@ class ComposableMap extends Component {
       projection,
       projectionConfig,
       width,
-      height,
+      height
     } = this.props
 
     return typeof projection !== "function" ?
@@ -29,6 +29,7 @@ class ComposableMap extends Component {
       style,
       showCenter,
       children,
+      aspectRatio
     } = this.props
 
     return (
@@ -36,7 +37,8 @@ class ComposableMap extends Component {
            height={ height }
            viewBox={ `0 0 ${width} ${height}` }
            className="rsm-svg"
-           style={ style }>
+           style={ style }
+           preserveAspectRatio={ aspectRatio }>
         {
           React.cloneElement(this.props.children, {
             projection: this.projection,
@@ -62,6 +64,7 @@ ComposableMap.defaultProps = {
   height: 450,
   projection: "times",
   projectionConfig: defaultProjectionConfig,
+  aspectRatio: "xMidYMid"
 }
 
 export default ComposableMap


### PR DESCRIPTION
I added an optional prop to adjust the aspect ratio of the ComposableMap element. I did this since I am layering several d3 elements on top of the rsm element, and needed all elements to be responsive in the same way.