### PR TITLE
Add className prop to ComposableMap

### DIFF
--- a/lib/ComposableMap.js
+++ b/lib/ComposableMap.js
@@ -57,6 +57,7 @@ var ComposableMap = function (_Component) {
           width = _props2.width,
           height = _props2.height,
           style = _props2.style,
+          className = _props2.className,
           showCenter = _props2.showCenter,
           children = _props2.children,
           aspectRatio = _props2.aspectRatio;
@@ -67,7 +68,7 @@ var ComposableMap = function (_Component) {
         { width: width,
           height: height,
           viewBox: "0 0 " + width + " " + height,
-          className: "rsm-svg",
+          className: "rsm-svg " + (className || ''),
           style: style,
           preserveAspectRatio: aspectRatio },
         _react2.default.cloneElement(this.props.children, {

--- a/src/ComposableMap.js
+++ b/src/ComposableMap.js
@@ -27,6 +27,7 @@ class ComposableMap extends Component {
       width,
       height,
       style,
+      className,
       showCenter,
       children,
       aspectRatio
@@ -36,7 +37,7 @@ class ComposableMap extends Component {
       <svg width={ width }
            height={ height }
            viewBox={ `0 0 ${width} ${height}` }
-           className="rsm-svg"
+           className={ `rsm-svg ${className || ''}` }
            style={ style }
            preserveAspectRatio={ aspectRatio }>
         {


### PR DESCRIPTION
Currently, applying custom styling via CSS modules requires wrapping the map in a div. This tweak is just to allow directly applying a class to the SVG.