### PR TITLE
closes #27: prevent markers from zooming

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,13 @@ Currently supported events are `onMouseEnter`, `onMouseLeave`, `onMouseDown`, `o
 
 #### <a name="Markers-component"></a> `<Markers />`
 
-`<Markers />` is a simple wrapper component for the individual markers.
+`<Markers />` is a simple wrapper component for the individual markers. You can choose to preserve the markers aspect/size when in a `<ZoomableGroup />`
+
+##### Props
+
+| Property            | Type            | Default                        |
+| ------------------- |:--------------- | :----------------------------- |
+| preserveAspectRatio | Boolean         | true                           |
 
 
 #### <a name="Marker-component"></a> `<Marker />`

--- a/lib/Geographies.js
+++ b/lib/Geographies.js
@@ -104,7 +104,6 @@ var Geographies = function (_Component) {
           style = _props2.style,
           children = _props2.children;
 
-
       return _react2.default.createElement(
         "g",
         { className: "rsm-geographies", style: style },

--- a/lib/Marker.js
+++ b/lib/Marker.js
@@ -163,16 +163,19 @@ var Marker = function (_Component) {
           marker = _props9.marker,
           style = _props9.style,
           tabable = _props9.tabable,
-          children = _props9.children;
+          zoom = _props9.zoom,
+          children = _props9.children,
+          preserveMarkerAspect = _props9.preserveMarkerAspect;
       var _state = this.state,
           pressed = _state.pressed,
           hover = _state.hover;
 
 
+      var scale = preserveMarkerAspect ? " scale(" + 1 / zoom + ")" : '';
       return _react2.default.createElement(
         "g",
         { className: "rsm-marker" + (pressed ? " rsm-marker--pressed" : "") + (hover ? " rsm-marker--hover" : ""),
-          transform: "translate(\n           " + projection()(marker.coordinates)[0] + "\n           " + projection()(marker.coordinates)[1] + "\n         )",
+          transform: "translate(\n           " + projection()(marker.coordinates)[0] + "\n           " + projection()(marker.coordinates)[1] + "\n         ) " + scale,
           style: style[pressed || hover ? pressed ? "pressed" : "hover" : "default"],
           onMouseEnter: this.handleMouseEnter,
           onMouseLeave: this.handleMouseLeave,

--- a/lib/Markers.js
+++ b/lib/Markers.js
@@ -33,18 +33,23 @@ var Markers = function (_Component) {
       var _props = this.props,
           children = _props.children,
           projection = _props.projection,
-          style = _props.style;
-
+          style = _props.style,
+          zoom = _props.zoom,
+          preserveMarkerAspect = _props.preserveMarkerAspect;
 
       return _react2.default.createElement(
         "g",
         { className: "rsm-markers", style: style },
         !children ? null : children.length === undefined ? _react2.default.cloneElement(children, {
-          projection: projection
+          projection: projection,
+          zoom: zoom,
+          preserveMarkerAspect: preserveMarkerAspect
         }) : children.map(function (child, i) {
           return !child ? null : _react2.default.cloneElement(child, {
             key: child.key || "marker-" + i,
-            projection: projection
+            projection: projection,
+            zoom: zoom,
+            preserveMarkerAspect: preserveMarkerAspect
           });
         })
       );
@@ -55,7 +60,8 @@ var Markers = function (_Component) {
 }(_react.Component);
 
 Markers.defaultProps = {
-  componentIdentifier: "Markers"
+  componentIdentifier: "Markers",
+  preserveMarkerAspect: true
 };
 
 exports.default = Markers;

--- a/lib/ZoomableGroup.js
+++ b/lib/ZoomableGroup.js
@@ -206,7 +206,6 @@ var ZoomableGroup = function (_Component) {
           resizeFactorX = _state2.resizeFactorX,
           resizeFactorY = _state2.resizeFactorY;
 
-
       return _react2.default.createElement(
         "g",
         { className: "rsm-zoomable-group",

--- a/src/Geographies.js
+++ b/src/Geographies.js
@@ -65,7 +65,6 @@ class Geographies extends Component {
       style,
       children,
     } = this.props
-
     return (
       <g className="rsm-geographies" style={ style }>
         { children(this.state.geographyPaths, projection) }

--- a/src/Marker.js
+++ b/src/Marker.js
@@ -86,7 +86,9 @@ class Marker extends Component {
       marker,
       style,
       tabable,
+      zoom,
       children,
+      preserveMarkerAspect,
     } = this.props
 
     const {
@@ -94,12 +96,13 @@ class Marker extends Component {
       hover,
     } = this.state
 
+    const scale = preserveMarkerAspect ? ` scale(${1/zoom})` : '';
     return (
       <g className={ `rsm-marker${ pressed ? " rsm-marker--pressed" : "" }${ hover ? " rsm-marker--hover" : "" }` }
          transform={ `translate(
            ${ projection()(marker.coordinates)[0] }
            ${ projection()(marker.coordinates)[1] }
-         )`}
+         ) ${scale}`}
          style={ style[pressed || hover ? (pressed ? "pressed" : "hover") : "default"] }
          onMouseEnter={ this.handleMouseEnter }
          onMouseLeave={ this.handleMouseLeave }

--- a/src/Markers.js
+++ b/src/Markers.js
@@ -8,8 +8,9 @@ class Markers extends Component {
       children,
       projection,
       style,
+      zoom,
+      preserveMarkerAspect,
     } = this.props
-
     return (
       <g className="rsm-markers" style={ style }>
         {
@@ -18,6 +19,8 @@ class Markers extends Component {
             children.length === undefined ?
               React.cloneElement(children, {
                 projection,
+                zoom,
+                preserveMarkerAspect
               }) :
               children.map((child, i) =>
                 !child ?
@@ -25,6 +28,8 @@ class Markers extends Component {
                   React.cloneElement(child, {
                     key: child.key || `marker-${i}`,
                     projection,
+                    zoom,
+                    preserveMarkerAspect
                   })
               )
         }
@@ -35,6 +40,7 @@ class Markers extends Component {
 
 Markers.defaultProps = {
   componentIdentifier: "Markers",
+  preserveMarkerAspect: true
 }
 
 export default Markers

--- a/src/ZoomableGroup.js
+++ b/src/ZoomableGroup.js
@@ -139,7 +139,6 @@ class ZoomableGroup extends Component {
       resizeFactorX,
       resizeFactorY,
     } = this.state
-
     return (
       <g className="rsm-zoomable-group"
          ref={ zoomableGroupNode => this.zoomableGroupNode = zoomableGroupNode }


### PR DESCRIPTION
This prevents markers from zooming in, particularly useful when rendering text!
I had tried to have the property at the `ZoomableGroup` level, with no success. Writing this, I'm almost thinking this could be at the `Marker` level, to allow zooming of non-text elements.