### PR TITLE
Ignore src and topojson-maps during distribution

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,5 @@
 .DS_Store
 node_modules
 examples
+src
+topojson-maps


### PR DESCRIPTION
5.6M of dead weight. Neither is necessary for distribution am I right?