### PR TITLE
closes #49: onGeographyPathsLoaded callback spell issue corrected

### DIFF
--- a/src/Geographies.js
+++ b/src/Geographies.js
@@ -37,11 +37,11 @@ class Geographies extends Component {
           this.setState({
             geographyPaths: feature(geographyPaths, geographyPaths.objects[Object.keys(geographyPaths.objects)[0]]).features,
           }, () => {
-            if (!this.props.onGeographiesLoaded) return
+            if (!this.props.onGeographyPathsLoaded) return
             this.props.onGeographyPathsLoaded(String(request.status))
           })
         } else {
-          if (!this.props.onGeographiesLoaded) return
+          if (!this.props.onGeographyPathsLoaded) return
           this.props.onGeographyPathsLoaded(String(request.status))
         }
       }


### PR DESCRIPTION
Perhaps, it was a silly spell issue. All test passed, the map is rendering completely fine and nowhere that prop - `onGeographiesLoaded` is used.