### PR TITLE
Improve geographies handling

### DIFF
--- a/lib/Geographies.js
+++ b/lib/Geographies.js
@@ -29,58 +29,22 @@ var Geographies = function (_Component) {
     var _this = _possibleConstructorReturn(this, (Geographies.__proto__ || Object.getPrototypeOf(Geographies)).call(this, props));
 
     _this.state = {
-      geographyPaths: ""
+      geographyPaths: _this.shouldFetchGeographies(props.geography) ? [] : _this.parseGeography(props.geography)
     };
-
-    _this.fetchGeographies = _this.fetchGeographies.bind(_this);
     return _this;
   }
 
   _createClass(Geographies, [{
-    key: "fetchGeographies",
-    value: function fetchGeographies(geography) {
-      var _this2 = this;
-
-      var _props = this.props,
-          width = _props.width,
-          height = _props.height;
-
-
-      if (!geography) return;else if (Object.prototype.toString.call(geography) === '[object Object]') {
-        this.setState({
-          geographyPaths: (0, _topojsonClient.feature)(geography, geography.objects[Object.keys(geography.objects)[0]]).features
-        });
-      } else if (Array.isArray(geography)) {
-        this.setState({ geographyPaths: geography });
-      } else {
-        var request = new XMLHttpRequest();
-        request.open("GET", geography, true);
-
-        request.onload = function () {
-          if (request.status >= 200 && request.status < 400) {
-            var geographyPaths = JSON.parse(request.responseText);
-            _this2.setState({
-              geographyPaths: (0, _topojsonClient.feature)(geographyPaths, geographyPaths.objects[Object.keys(geographyPaths.objects)[0]]).features
-            }, function () {
-              if (!_this2.props.onGeographiesLoaded) return;
-              _this2.props.onGeographyPathsLoaded(String(request.status));
-            });
-          } else {
-            if (!_this2.props.onGeographiesLoaded) return;
-            _this2.props.onGeographyPathsLoaded(String(request.status));
-          }
-        };
-        request.onerror = function () {
-          console.log("There was a connection error...");
-        };
-        request.send();
-      }
-    }
-  }, {
     key: "componentWillReceiveProps",
     value: function componentWillReceiveProps(nextProps) {
       if (nextProps.geography !== this.props.geography) {
-        this.fetchGeographies(nextProps.geography);
+        if (this.shouldFetchGeographies(nextProps.geography)) {
+          this.fetchGeographies(nextProps.geography);
+        } else {
+          this.setState({
+            geographyPaths: this.parseGeography(nextProps.geography)
+          });
+        }
       }
     }
   }, {
@@ -95,21 +59,85 @@ var Geographies = function (_Component) {
       if (this.props.geographyUrl || this.props.geographyPaths) {
         console.warn("You are using the deprecated geographyUrl or geographyPaths props. Use the new geography prop instead. Check out the new docs here: https://github.com/zcreativelabs/react-simple-maps#Geographies-component");
       }
-      this.fetchGeographies(this.props.geography);
+      if (this.shouldFetchGeographies(this.props.geography)) {
+        this.fetchGeographies(this.props.geography);
+      }
+    }
+  }, {
+    key: "componentWillUnmount",
+    value: function componentWillUnmount() {
+      this.cancelPendingRequest();
     }
   }, {
     key: "render",
     value: function render() {
-      var _props2 = this.props,
-          projection = _props2.projection,
-          style = _props2.style,
-          children = _props2.children;
+      var _props = this.props,
+          projection = _props.projection,
+          style = _props.style,
+          children = _props.children;
 
       return _react2.default.createElement(
         "g",
         { className: "rsm-geographies", style: style },
         children(this.state.geographyPaths || [], projection)
       );
+    }
+  }, {
+    key: "shouldFetchGeographies",
+    value: function shouldFetchGeographies(geography) {
+      return typeof geography === 'string';
+    }
+  }, {
+    key: "parseGeography",
+    value: function parseGeography(geography) {
+      if (Array.isArray(geography)) {
+        return geography;
+      }
+
+      if (Object.prototype.toString.call(geography) === '[object Object]') {
+        return (0, _topojsonClient.feature)(geography, geography.objects[Object.keys(geography.objects)[0]]).features;
+      }
+
+      return null;
+    }
+  }, {
+    key: "fetchGeographies",
+    value: function fetchGeographies(geography) {
+      var _this2 = this;
+
+      var request = new XMLHttpRequest();
+      request.open("GET", geography, true);
+      request.onload = function () {
+        if (request.status >= 200 && request.status < 400) {
+          var geographyPaths = JSON.parse(request.responseText);
+          _this2.setState({
+            geographyPaths: _this2.parseGeography(geographyPaths)
+          }, function () {
+            if (_this2.props.onGeographyPathsLoaded) {
+              _this2.props.onGeographyPathsLoaded(String(request.status));
+            }
+          });
+        } else {
+          if (_this2.props.onGeographyPathsLoaded) {
+            _this2.props.onGeographyPathsLoaded(String(request.status));
+          }
+        }
+      };
+      request.onerror = function () {
+        console.log("There was a connection error...");
+      };
+      request.send();
+
+      this.cancelPendingRequest();
+      this._xhr = request;
+    }
+  }, {
+    key: "cancelPendingRequest",
+    value: function cancelPendingRequest() {
+      if (this._xhr) {
+        this._xhr.abort();
+        thix._xhr = null;
+      }
     }
   }]);
 

--- a/src/Geographies.js
+++ b/src/Geographies.js
@@ -7,53 +7,20 @@ class Geographies extends Component {
     super(props)
 
     this.state = {
-      geographyPaths: "",
-    }
-
-    this.fetchGeographies = this.fetchGeographies.bind(this)
-  }
-  fetchGeographies(geography) {
-    const { width, height } = this.props
-
-    if(!geography) return
-
-    else if (Object.prototype.toString.call(geography) === '[object Object]') {
-      this.setState({
-          geographyPaths: feature(geography, geography.objects[Object.keys(geography.objects)[0]]).features
-        })
-    }
-
-    else if (Array.isArray(geography)) {
-      this.setState({ geographyPaths: geography })
-      }
-
-    else {
-      const request = new XMLHttpRequest()
-      request.open("GET", geography, true)
-
-      request.onload = () => {
-        if (request.status >= 200 && request.status < 400) {
-          const geographyPaths = JSON.parse(request.responseText)
-          this.setState({
-            geographyPaths: feature(geographyPaths, geographyPaths.objects[Object.keys(geographyPaths.objects)[0]]).features,
-          }, () => {
-            if (!this.props.onGeographiesLoaded) return
-            this.props.onGeographyPathsLoaded(String(request.status))
-          })
-        } else {
-          if (!this.props.onGeographiesLoaded) return
-          this.props.onGeographyPathsLoaded(String(request.status))
-        }
-      }
-      request.onerror = () => {
-        console.log("There was a connection error...")
-      }
-      request.send()
+      geographyPaths:
+        this.shouldFetchGeographies(props.geography) ? [] :
+          this.parseGeography(props.geography)
     }
   }
   componentWillReceiveProps(nextProps) {
     if (nextProps.geography !== this.props.geography) {
-      this.fetchGeographies(nextProps.geography)
+      if (this.shouldFetchGeographies(nextProps.geography)) {
+        this.fetchGeographies(nextProps.geography)
+      } else {
+        this.setState({
+          geographyPaths: this.parseGeography(nextProps.geography)
+        })
+      }
     }
   }
   shouldComponentUpdate(nextProps, nextState) {
@@ -64,7 +31,12 @@ class Geographies extends Component {
     if (this.props.geographyUrl || this.props.geographyPaths) {
       console.warn("You are using the deprecated geographyUrl or geographyPaths props. Use the new geography prop instead. Check out the new docs here: https://github.com/zcreativelabs/react-simple-maps#Geographies-component")
     }
-    this.fetchGeographies(this.props.geography)
+    if (this.shouldFetchGeographies(this.props.geography)) {
+      this.fetchGeographies(this.props.geography)
+    }
+  }
+  componentWillUnmount() {
+    this.cancelPendingRequest()
   }
   render() {
     const {
@@ -77,6 +49,53 @@ class Geographies extends Component {
         { children(this.state.geographyPaths || [], projection) }
       </g>
     )
+  }
+  shouldFetchGeographies(geography) {
+    return typeof(geography) === 'string'
+  }
+  parseGeography(geography) {
+    if (Array.isArray(geography)) {
+      return geography
+    }
+
+    if (Object.prototype.toString.call(geography) === '[object Object]') {
+      return feature(geography, geography.objects[Object.keys(geography.objects)[0]]).features
+    }
+
+    return []
+  }
+  fetchGeographies(geography) {
+    const request = new XMLHttpRequest()
+    request.open("GET", geography, true)
+    request.onload = () => {
+      if (request.status >= 200 && request.status < 400) {
+        const geographyPaths = JSON.parse(request.responseText)
+        this.setState({
+          geographyPaths: this.parseGeography(geographyPaths),
+        }, () => {
+          if (this.props.onGeographyPathsLoaded) {
+            this.props.onGeographyPathsLoaded(String(request.status))
+          }
+        })
+      } else {
+        if (this.props.onGeographyPathsLoaded) {
+          this.props.onGeographyPathsLoaded(String(request.status))
+        }
+      }
+    }
+    request.onerror = () => {
+      console.log("There was a connection error...")
+    }
+    request.send()
+
+    this.cancelPendingRequest()
+    this._xhr = request
+  }
+  cancelPendingRequest() {
+    if (this._xhr) {
+      this._xhr.abort()
+      thix._xhr = null
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds a little logic around XHR fetching and fixes couple of existing issues:

1. Makes geography data passed in props available immediately. Previously there would be no data until `componentDidMount` which caused the first render pass to happen with empty geographies. (#51)

2. Better XHR handling, particularly fixes the issue with XHR request running after the component is unmounted.

3. Covers #49 