### PR TITLE
use new projection to calculate mouse position

### DIFF
--- a/src/ZoomableGroup.js
+++ b/src/ZoomableGroup.js
@@ -102,8 +102,8 @@ class ZoomableGroup extends Component {
 
     this.setState({
       zoom: nextProps.zoom,
-      mouseX: centerChanged ? calculateMousePosition("x", projection, nextProps, nextProps.zoom, resizeFactorX) : mouseX * zoomFactor,
-      mouseY: centerChanged ? calculateMousePosition("y", projection, nextProps, nextProps.zoom, resizeFactorY) : mouseY * zoomFactor,
+      mouseX: centerChanged ? calculateMousePosition("x", nextProps.projection, nextProps, nextProps.zoom, resizeFactorX) : mouseX * zoomFactor,
+      mouseY: centerChanged ? calculateMousePosition("y", nextProps.projection, nextProps, nextProps.zoom, resizeFactorY) : mouseY * zoomFactor,
     })
   }
   handleResize() {


### PR DESCRIPTION
Hi, I encountered an issue that my map was at wrong location after updating `projectionConfig`. After investigation, I found that changing `projection` to `nextProps.projection` in `componentWillReceiveProps` fixed the problem.