### PR TITLE
Hide markers only when on a globe

### DIFF
--- a/lib/Marker.js
+++ b/lib/Marker.js
@@ -186,7 +186,10 @@ var Marker = function (_Component) {
         }
       };
 
-      var isHidden = (0, _d3Geo.geoLength)(lineString) > 1.5708;
+      var radians = Math.PI / 2,
+          degrees = 90;
+      var isGlobe = projection.clipAngle() === degrees;
+      var isHidden = isGlobe && (0, _d3Geo.geoLength)(lineString) > radians;
 
       return _react2.default.createElement(
         "g",

--- a/src/Marker.js
+++ b/src/Marker.js
@@ -113,7 +113,9 @@ class Marker extends Component {
       },
     }
 
-    const isHidden = geoLength(lineString) > 1.5708
+    const radians = Math.PI/2, degrees = 90
+    const isGlobe = projection.clipAngle() === degrees
+    const isHidden = isGlobe && geoLength(lineString) > radians
 
     return (
       <g className={ `rsm-marker${ pressed ? " rsm-marker--pressed" : "" }${ hover ? " rsm-marker--hover" : "" }` }


### PR DESCRIPTION
Markers are currently incorrectly being hidden when displayed on a map. See issue #73 
In this case we are detecting if the marker is placed on a globe in which case we allow for hiding.

I tried out allowing for user override of this but eventually realized that it would basically be allowing for weird behavior like the one in described in the issue. 