### PR TITLE
Fix the resize factor if the actual size is 0

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,7 @@ var _react2 = _interopRequireDefault(_react);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function calculateResizeFactor(actualDimension, baseDimension) {
+  if (actualDimension === 0) return 1;
   return 1 / 100 * (100 / actualDimension * baseDimension);
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,7 @@
 import React from "react"
 
 export function calculateResizeFactor(actualDimension, baseDimension) {
+  if (actualDimension === 0) return 1;
   return 1 / 100 * (100 / actualDimension * baseDimension)
 }
 

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -46,13 +46,17 @@ describe("roundPath", () => {
 
 describe("calculateResizeFactor", () => {
   it("should return proper dimensions for variable ratios", () => {
-    const actualDimension = 1600
-    const baseDimension = 800
+    const actualDimension = [1600, 0]
+    const baseDimension = [800, 960]
 
-    const actual = calculateResizeFactor(actualDimension, baseDimension)
-    const expected = 0.5
+    const actual = [
+        calculateResizeFactor(actualDimension[0], baseDimension[0]),
+        calculateResizeFactor(actualDimension[1], baseDimension[1]),
+    ]
+    const expected = [0.5, 1]
 
-    expect(actual).toEqual(expected)
+    expect(actual[0]).toEqual(expected[0])
+    expect(actual[1]).toEqual(expected[1])
   })
 })
 


### PR DESCRIPTION
Resolves an issue where the function calculateResizeFactor would return 'infinit'
due to a division by 0. This could lead to errors in the ZoomableGroup where the transform
woulde resolve to 'translate(NaN, NaN)'