### PR TITLE
Upgrade d3-geo and d3-geo-projection to avoid multiple versions in bundles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -963,13 +963,23 @@
       }
     },
     "d3-geo-projection": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-1.2.2.tgz",
-      "integrity": "sha1-7w5s3PoN8jbQ4j8sp3UEYsozH3I=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-2.4.0.tgz",
+      "integrity": "sha512-LigP464w4R5WTE58AOVHdFvjym/4z58DfRFKUBAfuCU/sCLXuxfNs74JUdoQ0kd6+WaSp95en0lUHk/YjaIYdg==",
       "requires": {
         "commander": "2.11.0",
         "d3-array": "1.2.1",
-        "d3-geo": "1.6.3"
+        "d3-geo": "1.10.0"
+      },
+      "dependencies": {
+        "d3-geo": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.10.0.tgz",
+          "integrity": "sha512-VK/buVGgexthTTqGRNXQ/LSo3EbOFu4p2Pjud5drSIaEnOaF2moc8A3P7WEljEO1JEBEwbpAJjFWMuJiUtoBcw==",
+          "requires": {
+            "d3-array": "1.2.1"
+          }
+        }
       }
     },
     "debug": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -955,9 +955,9 @@
       "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
     },
     "d3-geo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.6.3.tgz",
-      "integrity": "sha1-IWg6Q6Bh6rohp/JUtR1ZN+tkB1Y=",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.10.0.tgz",
+      "integrity": "sha512-VK/buVGgexthTTqGRNXQ/LSo3EbOFu4p2Pjud5drSIaEnOaF2moc8A3P7WEljEO1JEBEwbpAJjFWMuJiUtoBcw==",
       "requires": {
         "d3-array": "1.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "d3-geo": "1.6.3",
-    "d3-geo-projection": "1.2.2",
+    "d3-geo-projection": "2.4.0",
     "topojson-client": "2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-dom": "^0.14.9 || ^15.3.0 || ^16.0.0-rc || ^16.0"
   },
   "dependencies": {
-    "d3-geo": "1.6.3",
+    "d3-geo": "1.10.0",
     "d3-geo-projection": "2.4.0",
     "topojson-client": "2.1.0"
   }


### PR DESCRIPTION
At the moment the following dependency tree means my team has two versions of d3-geo in our bundle:
- react-simple-maps: ^0.12.1
  - d3-geo: 1.6.3,
  - d3-geo-projection: 1.2.2
    - d3-geo: ^1.1.0

This can be avoided by upgrading d3-geo-projection to the lastest version (2.4.0) and d3-geo to the version depended on by d3-geo-projection@2.4.0 (1.10.0). 

Looking at the release notes for d3-geo-projection to looks like the majour version bump to 2.0.0 inolved updates to two method that aren't used in directly in this repo.
https://github.com/d3/d3-geo-projection/releases/tag/v2.0.0

Bundle before (react-simple-maps total size 163.47kb): 
![image](https://user-images.githubusercontent.com/11618615/40727384-af8608e0-641f-11e8-88bc-b777ea6e08e7.png)

Bundle after  (react-simple-maps total size 150.75kb): 
![image](https://user-images.githubusercontent.com/11618615/40727398-b59db4bc-641f-11e8-8950-d1e0c3e46b5a.png)
