### PR TITLE
Replace componentWillReceiveProps with componentDidUpdate

### DIFF
--- a/src/Geographies.js
+++ b/src/Geographies.js
@@ -12,13 +12,13 @@ class Geographies extends Component {
           this.parseGeographies(props.geography)
     }
   }
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.geography !== this.props.geography) {
-      if (this.shouldFetchGeographies(nextProps.geography)) {
-        this.fetchGeographies(nextProps.geography)
+  componentDidUpdate(prevProps) {
+    if (prevProps.geography !== this.props.geography) {
+      if (this.shouldFetchGeographies(prevProps.geography)) {
+        this.fetchGeographies(prevProps.geography)
       } else {
         this.setState({
-          geographyPaths: this.parseGeographies(nextProps.geography)
+          geographyPaths: this.parseGeographies(prevProps.geography)
         })
       }
     }

--- a/src/Graticule.js
+++ b/src/Graticule.js
@@ -45,7 +45,7 @@ class Graticule extends Component {
         : computeOutline(projection),
     })
   }
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     const {
       step,
       projection,
@@ -54,12 +54,12 @@ class Graticule extends Component {
       globe,
     } = this.props
 
-    if (nextProps.round !== round || nextProps.precision !== precision || globe) {
+    if (prevProps.round !== round || prevProps.precision !== precision || globe) {
       this.setState({
-        graticulePath: nextProps.round
+        graticulePath: prevProps.round
           ? roundPath(computeGraticule(projection, step), precision)
           : computeGraticule(projection, step),
-        outlinePath: nextProps.round
+        outlinePath: prevProps.round
           ? roundPath(computeOutline(projection), precision)
           : computeOutline(projection),
       })

--- a/src/ZoomableGlobe.js
+++ b/src/ZoomableGlobe.js
@@ -85,16 +85,16 @@ class ZoomableGlobe extends Component {
       evt.preventDefault()
     }
   }
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     const { mouseX, mouseY } = this.state
     const { projection, center, zoom } = this.props
 
-    const zoomFactor = nextProps.zoom / zoom
-    const centerChanged = JSON.stringify(nextProps.center) !== JSON.stringify(center)
+    const zoomFactor = prevProps.zoom / zoom
+    const centerChanged = JSON.stringify(prevProps.center) !== JSON.stringify(center)
 
     this.setState({
-      zoom: nextProps.zoom,
-      rotation: centerChanged ? [-nextProps.center[0], -nextProps.center[1], this.state.rotation[2]] : this.state.rotation,
+      zoom: prevProps.zoom,
+      rotation: centerChanged ? [-prevProps.center[0], -prevProps.center[1], this.state.rotation[2]] : this.state.rotation,
     })
   }
   componentDidMount() {

--- a/src/ZoomableGroup.js
+++ b/src/ZoomableGroup.js
@@ -92,17 +92,17 @@ class ZoomableGroup extends Component {
       evt.preventDefault()
     }
   }
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     const { mouseX, mouseY, resizeFactorX, resizeFactorY } = this.state
     const { projection, center, zoom } = this.props
 
-    const zoomFactor = nextProps.zoom / zoom
-    const centerChanged = JSON.stringify(nextProps.center) !== JSON.stringify(center)
+    const zoomFactor = prevProps.zoom / zoom
+    const centerChanged = JSON.stringify(prevProps.center) !== JSON.stringify(center)
 
     this.setState({
-      zoom: nextProps.zoom,
-      mouseX: centerChanged ? calculateMousePosition("x", nextProps.projection, nextProps, nextProps.zoom, resizeFactorX) : mouseX * zoomFactor,
-      mouseY: centerChanged ? calculateMousePosition("y", nextProps.projection, nextProps, nextProps.zoom, resizeFactorY) : mouseY * zoomFactor,
+      zoom: prevProps.zoom,
+      mouseX: centerChanged ? calculateMousePosition("x", prevProps.projection, prevProps, prevProps.zoom, resizeFactorX) : mouseX * zoomFactor,
+      mouseY: centerChanged ? calculateMousePosition("y", prevProps.projection, prevProps, prevProps.zoom, resizeFactorY) : mouseY * zoomFactor,
     })
   }
   handleResize() {


### PR DESCRIPTION
`componentWillReceiveProps` will be renamed [`UNSAFE_componentWillReceiveProps` in react 17](https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops) and reults in console errors when run in React strict mode.

This PR replaces all use of `componentWillReceiveProps` with `componentDidUpdate`. While this should be sufficient, more optimizations might be found [switching to some memoized functions](https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#what-about-memoization). 