### PR TITLE
add geoEquirectangular

### DIFF
--- a/src/components/MapProvider.js
+++ b/src/components/MapProvider.js
@@ -17,6 +17,7 @@ import {
   geoConicConformal,
   geoConicEqualArea,
   geoConicEquidistant,
+  geoEquirectangular,
 } from "d3-geo"
 
 const MapContext = createContext()
@@ -33,6 +34,7 @@ const projections = {
   geoConicConformal,
   geoConicEqualArea,
   geoConicEquidistant,
+  geoEquirectangular,
 }
 
 const makeProjection = ({


### PR DESCRIPTION
This was the default on the previous version.  It seems it was missing from the latest.

I can't make it look like the old version of react-simple-maps though.  It seems all stretched out