### PR TITLE
ADD filter func on zoom event

### DIFF
--- a/src/components/ZoomableGroup.js
+++ b/src/components/ZoomableGroup.js
@@ -11,6 +11,7 @@ const ZoomableGroup = ({
   minZoom = 1,
   maxZoom = 8,
   translateExtent,
+  filterZoomEvent,
   onMoveStart,
   onMove,
   onMoveEnd,
@@ -24,6 +25,7 @@ const ZoomableGroup = ({
     transformString,
   } = useZoomPan({
     center,
+    filterZoomEvent,
     onMoveStart,
     onMove,
     onMoveEnd,

--- a/src/components/useZoomPan.js
+++ b/src/components/useZoomPan.js
@@ -61,8 +61,9 @@ export default function useZoomPan({
       if (filter) {
         return filterZoomEvent(d3Event)
       }
-
-      return true
+      
+      // DEFAULT => Ignore right-click, since that should open the context menu.
+      return !event.ctrlKey && !event.button;
     }
 
     const zoom = d3Zoom()

--- a/src/components/useZoomPan.js
+++ b/src/components/useZoomPan.js
@@ -63,7 +63,7 @@ export default function useZoomPan({
       }
       
       // DEFAULT => Ignore right-click, since that should open the context menu.
-      return !event.ctrlKey && !event.button;
+      return !d3Event.ctrlKey && !d3Event.button;
     }
 
     const zoom = d3Zoom()

--- a/src/components/useZoomPan.js
+++ b/src/components/useZoomPan.js
@@ -58,7 +58,7 @@ export default function useZoomPan({
     }
 
     function filterFunc() {
-      if (filter) {
+      if (filterZoomEvent) {
         return filterZoomEvent(d3Event)
       }
       

--- a/src/components/useZoomPan.js
+++ b/src/components/useZoomPan.js
@@ -8,6 +8,7 @@ import { getCoords } from "../utils"
 
 export default function useZoomPan({
   center,
+  filterZoomEvent,
   onMoveStart,
   onMoveEnd,
   onMove,
@@ -56,7 +57,16 @@ export default function useZoomPan({
       onMoveEnd({ coordinates: [x, y], zoom: d3Event.transform.k }, d3Event)
     }
 
+    function filterFunc() {
+      if (filter) {
+        return filterZoomEvent(d3Event)
+      }
+
+      return true
+    }
+
     const zoom = d3Zoom()
+      .filter(filterFunc)
       .scaleExtent([minZoom, maxZoom])
       .translateExtent([[a1, a1], [b1, b2]])
       .on("start", handleZoomStart)


### PR DESCRIPTION
Hi,
I need the filter func on zoom event for filter some gesture.
For example:
```
const filter = useCallback((d3Event) => {
    return d3Event.ctrlKey
  }, []);

...
<ZoomableGroup zoom={1} filterZoomEvent={filter}  >
...
```

SEE d3-zoom doc => https://github.com/d3/d3-zoom#zoom_filter