### PR TITLE
Unify scaleFactor `k` for `onMove` event

### DIFF
--- a/src/components/useZoomPan.js
+++ b/src/components/useZoomPan.js
@@ -48,7 +48,7 @@ export default function useZoomPan({
       const {transform, sourceEvent} = d3Event
       setPosition({ x: transform.x, y: transform.y, k: transform.k, dragging: sourceEvent })
       if (!onMove) return
-      onMove({ x: transform.x, y: transform.y, k: transform.k, dragging: sourceEvent }, d3Event)
+      onMove({ x: transform.x, y: transform.y, zoom: transform.k, dragging: sourceEvent }, d3Event)
     }
   
     function handleZoomEnd(d3Event) {


### PR DESCRIPTION
D3's scale factor `k` is exposed in `onMoveEnd`, `onMoveStart` and
couple of other places as `zoom` variable, but not here. It creates
confusion. Now it should be more clear