### PR TITLE
Added support for React 18.x 

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "react-test-utils": "^0.0.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || 17.x",
-    "react-dom": "^16.8.0 || 17.x",
+    "react": "^16.8.0 || 17.x || 18.x",
+    "react-dom": "^16.8.0 || 17.x || 18.x",
     "prop-types": "^15.7.2"
   },
   "dependencies": {


### PR DESCRIPTION
Added lines in package.json as peerDepencies to support React v18.

```javascript
"peerDependencies": {
    "react": "^16.8.0 || 17.x || 18.x",
    "react-dom": "^16.8.0 || 17.x || 18.x",
    "prop-types": "^15.7.2"
  },
```