### PR TITLE
fix(components/useGeographies): allow SSR with JSON

### DIFF
--- a/src/components/useGeographies.js
+++ b/src/components/useGeographies.js
@@ -15,11 +15,9 @@ export default function useGeographies({ geography, parseGeographies }) {
   const [output, setOutput] = useState({})
 
   useEffect(() => {
-    if (typeof window === `undefined`) return
-
     if (!geography) return
 
-    if (isString(geography)) {
+    if (isString(geography) && typeof window !== `undefined`) {
       fetchGeographies(geography).then((geos) => {
         if (geos) {
           setOutput({


### PR DESCRIPTION
This patch updates the `useGeographies` hook to allow server-side rendering when passing in a static JS object (e.g. from a local JSON file). This hook will still prevent trying to fetch external geography data when rendering server-side.