### PR TITLE
bump react and react-dom version for React 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,8 +36,8 @@
       },
       "peerDependencies": {
         "prop-types": "^15.7.2",
-        "react": "^16.8.0 || 17.x || 18.x",
-        "react-dom": "^16.8.0 || 17.x || 18.x"
+        "react": "^16.8.0 || 17.x || 18.x || 19.x",
+        "react-dom": "^16.8.0 || 17.x || 18.x || 19.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",
-    "react": "^16.8.0 || 17.x || 18.x",
-    "react-dom": "^16.8.0 || 17.x || 18.x"
+    "react": "^16.8.0 || 17.x || 18.x || 19.x",
+    "react-dom": "^16.8.0 || 17.x || 18.x || 19.x"
   },
   "dependencies": {
     "d3-color": "^3.1.0",


### PR DESCRIPTION
I can't use react-simple-maps in my React 19 project without using this workaround: https://github.com/zcreativelabs/react-simple-maps/issues/367

This PR would bump the allowed versions for react and react-dom to allow v19.